### PR TITLE
デプロイ失敗対応  fix:reviewsテーブルのproduct_idのnull許可へ変更

### DIFF
--- a/db/migrate/20250702161960_add_product_ref_to_reviews.rb
+++ b/db/migrate/20250702161960_add_product_ref_to_reviews.rb
@@ -1,5 +1,5 @@
 class AddProductRefToReviews < ActiveRecord::Migration[7.2]
   def change
-    add_reference :reviews, :product, null: false, foreign_key: true
+    add_reference :reviews, :product, null: true, foreign_key: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,7 +28,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_02_184703) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "product_id", null: false
+    t.bigint "product_id"
     t.index ["product_id"], name: "index_reviews_on_product_id"
     t.index ["user_id"], name: "index_reviews_on_user_id"
   end


### PR DESCRIPTION
## 概要

デプロイ失敗したため、カラムの制約を修正しました。

失敗の原因は、
本番環境にレコード存在するデータがあり、そこに整合性のとれない
カラムを追加したため。
