### PR TITLE
デプロイ修正　fix:外部キーのnullを許可しないように変更

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,5 +3,5 @@ set -o errexit
 bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
-# bundle exec rails db:migrate
-DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake db:migrate:reset
+bundle exec rails db:migrate
+# DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake db:migrate:reset

--- a/db/migrate/20250702161960_add_product_ref_to_reviews.rb
+++ b/db/migrate/20250702161960_add_product_ref_to_reviews.rb
@@ -1,5 +1,5 @@
 class AddProductRefToReviews < ActiveRecord::Migration[7.2]
   def change
-    add_reference :reviews, :product, null: true, foreign_key: true
+    add_reference :reviews, :product, null: false, foreign_key: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,7 +28,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_02_184703) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "product_id"
+    t.bigint "product_id", null: false
     t.index ["product_id"], name: "index_reviews_on_product_id"
     t.index ["user_id"], name: "index_reviews_on_user_id"
   end


### PR DESCRIPTION
今までのデプロイ修正の流れ

ReviewデータのProductデータと紐付ける外部キーをnullを許可しない設定でデプロイしたら、本番環境に既存のReviewデータのレコードが存在してたため、データの整合性がとれなくなり、デプロイ失敗

これまでの修正の流れ
1. 一度nullを許可する制約に修正してデプロイ
2. nullを許可したことにより、デプロイ失敗問題は解決。だが、一覧ビューでの商品情報を表示するロジックを実装してしまってたため、エラーになった。なので、本番環境のデータをリセットする。
3. リセットしたデプロイがOKだったので、再度外部キーをnullを許可しないに変更しデプロイする。今ここ