### PR TITLE
add:レビュー削除機能

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -5,6 +5,7 @@ class ReviewsController < ApplicationController
   end
 
   def show
+    @review = current_user.reviews.find(params[:id])
   end
 
   def new
@@ -30,6 +31,9 @@ class ReviewsController < ApplicationController
   end
 
   def destroy
+    @review = current_user.reviews.find(params[:id])
+    @review.destroy
+    redirect_to reviews_path, notice: 'saccessfully deleted.'
   end
 
   private

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -1,6 +1,9 @@
 <h1>Reviews#index</h1>
 <p>Find me in app/views/reviews/index.html.erb</p>
+
 <% @reviews.each do |review| %>
+<%# This is a loop to display each review %>
+    <%= link_to 'delete', review_path(review), data: { turbo_method: :delete, turbo_confirm: 'really' }  %>
     <div>
         <p>review id: <%= review.id%></p>
         <p><%= review.product.name%></p>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -1,2 +1,8 @@
-<h1>Reviews#show</h1>
-<p>Find me in app/views/reviews/show.html.erb</p>
+<h1>詳細ページです</h1>
+
+<%= link_to '削除', review_path(@review), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } %>
+<P>レビュIDは<%= @review.id%>です</P>
+<p>商品名は<%= @review.product.name %>です</p>
+<p>レビュー内容は<%= @review.body %>です</p>
+<p>レビュアーIDは<%= @review.user.id %>です</p>
+<p>レビュアー名は<%= @review.user.name %>です</p


### PR DESCRIPTION
## 概要

レビュー投稿削除機能を追加しました。
- **追加した背景**
レビュー投稿の実装を進める中で、テーブルを追加したり、カラムを追加したりするなかで既存のレコードのせいでよくデータの整合性が取れなくなことがあったので
削除できる機能を追加する。これにより、既存レコードが有った場合は
デプロイする前に削除でき、データの整合性を保つ狙い。