### PR TITLE
フラッシュメッセージとデータの翻訳

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,11 +2,18 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
   before_action :set_header_visibility
-  before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :store_locale_before_logout, if: -> { controller_name == 'sessions' && action_name == 'destroy' }
+  before_action :store_user_locale_to_session, unless: -> { controller_name == 'sessions' && action_name == 'destroy' }
   before_action :set_locale
+  before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!
+  
 
-
+  def store_locale_before_logout
+    Rails.logger.debug "[Locale] Before logout - setting locale to: #{current_user&.language}"
+    session[:locale] = current_user.language if current_user&.language.present?
+    I18n.locale = current_user.language.to_sym if current_user&.language.present?
+  end
   protected
 
   def configure_permitted_parameters
@@ -16,25 +23,44 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def after_sign_in_path_for(resource)
-    root_path # ログイン後に遷移するpathを設定
-  end
-
-  def after_sign_out_path_for(resource)
-    root_path # ログアウト後に遷移するpathを設定
-  end
-
   def set_header_visibility
     @header_visible = true
   end
 
+  def store_user_locale_to_session # このメソッドは、ユーザーがログインしている場合に、そのユーザーの言語設定をセッションに保存します。
+    session[:locale] = current_user.language if user_signed_in? && current_user.language.present?
+  end
+
   def set_locale
-    if user_signed_in? && current_user.language.present?
-      I18n.locale = current_user.language.to_sym
-    elsif session[:locale].present?
-      I18n.locale = session[:locale].to_sym
-    else
-      I18n.locale = I18n.default_locale
+    I18n.locale =
+      if user_signed_in? && current_user.language.present?
+        session[:locale] = current_user.language
+        current_user.language.to_sym
+      elsif session[:locale].present?
+        session[:locale].to_sym
+      else
+        I18n.default_locale
+      end
+  end
+
+  def after_sign_out_path_for(resource_or_scope)
+    flash[:notice] = I18n.t('devise.sessions.signed_out')
+    puts (session[:locale].to_s + 'ログアウト後のsession')
+    puts (I18n.locale.to_s + 'ログアウト後のI18n.locale') 
+    root_path
+  end
+
+  def after_sign_in_path_for(resource)
+    if resource.respond_to?(:language) && resource.language.present?
+      session[:locale] = resource.language
+      I18n.locale = resource.language.to_sym
     end
+
+    flash[:notice] = I18n.t('devise.sessions.signed_in') # ログイン後のメッセージ
+
+    puts session[:locale] # Debugging
+    puts (I18n.locale.to_s + 'サイン後のI18n.locale')
+
+    root_path
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,12 +2,12 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
   before_action :set_header_visibility
-  before_action :store_locale_before_logout, if: -> { controller_name == 'sessions' && action_name == 'destroy' }
-  before_action :store_user_locale_to_session, unless: -> { controller_name == 'sessions' && action_name == 'destroy' }
+  before_action :store_locale_before_logout, if: -> { controller_name == "sessions" && action_name == "destroy" }
+  before_action :store_user_locale_to_session, unless: -> { controller_name == "sessions" && action_name == "destroy" }
   before_action :set_locale
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!
-  
+
 
   def store_locale_before_logout
     Rails.logger.debug "[Locale] Before logout - setting locale to: #{current_user&.language}"
@@ -44,9 +44,9 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_out_path_for(resource_or_scope)
-    flash[:notice] = I18n.t('devise.sessions.signed_out')
-    puts (session[:locale].to_s + 'ログアウト後のsession')
-    puts (I18n.locale.to_s + 'ログアウト後のI18n.locale') 
+    flash[:notice] = I18n.t("devise.sessions.signed_out")
+    puts (session[:locale].to_s + "ログアウト後のsession")
+    puts (I18n.locale.to_s + "ログアウト後のI18n.locale")
     root_path
   end
 
@@ -56,10 +56,10 @@ class ApplicationController < ActionController::Base
       I18n.locale = resource.language.to_sym
     end
 
-    flash[:notice] = I18n.t('devise.sessions.signed_in') # ログイン後のメッセージ
+    flash[:notice] = I18n.t("devise.sessions.signed_in") # ログイン後のメッセージ
 
     puts session[:locale] # Debugging
-    puts (I18n.locale.to_s + 'サイン後のI18n.locale')
+    puts (I18n.locale.to_s + "サイン後のI18n.locale")
 
     root_path
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,12 +1,12 @@
 module ApplicationHelper
   def localized_category_options
     Category.all.map do |category|
-      [category.localized_name, category.id]
+      [ category.localized_name, category.id ]
     end
   end
 
   def display_category_name(review)
-    return t('defaults.none') unless review.categories.present?
+    return t("defaults.none") unless review.categories.present?
     review.categories.first.localized_name
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,12 @@
 module ApplicationHelper
+  def localized_category_options
+    Category.all.map do |category|
+      [category.localized_name, category.id]
+    end
+  end
+
+  def display_category_name(review)
+    return t('defaults.none') unless review.categories.present?
+    review.categories.first.localized_name
+  end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,27 @@
 class Category < ApplicationRecord
   has_many :review_categories
   has_many :reviews, through: :review_categories
+
+  def localized_name
+    # nameを翻訳キーに変換（例: "韓国料理" → "korean_food"）
+    translation_key = convert_name_to_key(name)
+    I18n.t("categories.#{translation_key}", default: name)
+  end
+
+  private
+
+  def convert_name_to_key(name)
+    # 日本語名から翻訳キーへの変換マッピング
+    name_to_key_mapping = {
+    #   '韓国料理' => 'korean_food',
+    #   '日本料理' => 'japanese_food',
+    #   '中華料理' => 'chinese_food',
+    #   '洋食' => 'western_food',
+    #   'スナック' => 'snack',
+    #   'ドリンク' => 'drink',
+      'デザート' => 'dessert',
+    #   'インスタント食品' => 'instant_food'
+    }
+    name_to_key_mapping[name] || name.downcase.gsub(/[^a-z0-9]/, '_')
+  end  
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -13,15 +13,15 @@ class Category < ApplicationRecord
   def convert_name_to_key(name)
     # 日本語名から翻訳キーへの変換マッピング
     name_to_key_mapping = {
-    #   '韓国料理' => 'korean_food',
-    #   '日本料理' => 'japanese_food',
-    #   '中華料理' => 'chinese_food',
-    #   '洋食' => 'western_food',
-    #   'スナック' => 'snack',
-    #   'ドリンク' => 'drink',
-      'デザート' => 'dessert',
-    #   'インスタント食品' => 'instant_food'
+      #   '韓国料理' => 'korean_food',
+      #   '日本料理' => 'japanese_food',
+      #   '中華料理' => 'chinese_food',
+      #   '洋食' => 'western_food',
+      #   'スナック' => 'snack',
+      #   'ドリンク' => 'drink',
+      "デザート" => "dessert"
+      #   'インスタント食品' => 'instant_food'
     }
-    name_to_key_mapping[name] || name.downcase.gsub(/[^a-z0-9]/, '_')
-  end  
+    name_to_key_mapping[name] || name.downcase.gsub(/[^a-z0-9]/, "_")
+  end
 end

--- a/app/views/forms/_review_form.html.erb
+++ b/app/views/forms/_review_form.html.erb
@@ -19,10 +19,11 @@
         <%= f.select :rating, options_for_select((0..5).map { |n| [n, n] },@review_form.rating.to_i), {}, class: 'form-select' %>
         
         <%= f.label :category_id, class: 'form-label' %>
-        <%= f.collection_select :category_id, Category.all, :id, :name, {include_blank: 'なし'}, class: 'form-select', placeholder: 'faf' %>   
+        <%= f.collection_select :category_id, Category.all, :id, :name, {include_blank: t('reviews.show.none')}, class: 'form-select', placeholder: 'faf' %>  
+        <%#<%= f.select :category_id, options_for_select(localized_category_options, @review_form.category_id),{ include_blank: t('reviews.show.none') }, { class: 'form-select' } %> 
 
         <%= f.label :taste_id, class: 'form-label' %>
-        <%= f.collection_select :taste_id, Taste.all, :id, :name, {include_blank: 'なし'}, class: 'form-select' %>   
+        <%= f.collection_select :taste_id, Taste.all, :id, :name, {include_blank: t('reviews.show.none')}, class: 'form-select' %>   
 
         <%= f.label :body, class: 'form-label' %>
         <%= f.text_area :body, class:'form-control', style: 'height: 150px;' %>

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -20,10 +20,10 @@
         <%= f.select :rating, options_for_select((0..5).map { |n| [n, n] }, @review_form.rating.to_i), {}, class: 'form-select' %>
         
         <%= f.label :category_id, class: 'form-label' %>
-        <%= f.collection_select :category_id, Category.all, :id, :name, {include_blank: 'none'}, class: 'form-select' %>   
+        <%= f.collection_select :category_id, Category.all, :id, :name, {include_blank: t('reviews.show.none')}, class: 'form-select' %>   
 
         <%= f.label :taste_id, class: 'form-label' %>
-        <%= f.collection_select :taste_id, Taste.all, :id, :name, {include_blank: 'none'}, class: 'form-select' %>   
+        <%= f.collection_select :taste_id, Taste.all, :id, :name, {include_blank: t('reviews.show.none')}, class: 'form-select' %>   
 
         <%= f.label :body, class: 'form-label' %>
         <%= f.text_area :body, class:'form-control ', style: 'height: 150px;' %>

--- a/config/locales/moldels/ja.yml
+++ b/config/locales/moldels/ja.yml
@@ -1,0 +1,30 @@
+ja:
+  activerecord:
+    attributes:
+      review:
+        conveniencestore: "コンビニ"
+        product_name: "商品名"
+        price: "価格"
+        rating: "総合評価"
+        category: "カテゴリー"
+        taste: "味覚"
+        body: "レビュー内容"
+        image: "画像"
+  categories:
+    # korean_food: "한국 요리"
+    # japanese_food: "일본 요리"
+    # chinese_food: "중국 요리"
+    # western_food: "양식"
+    # snack: "스낵"
+    # drink: "음료"
+    dessert: "デザート"
+    # instant_food: "인스턴트 식품"
+  tastes:
+    spicy: "辛い味"
+    # sweet: "단맛"
+    # sour: "신맛"
+    # bitter: "쓴맛"
+    # salty: "짠맛"
+    # umami: "감칠맛"
+    # mild: "부드러운맛"
+    # rich: "진한맛"

--- a/config/locales/moldels/ko.yml
+++ b/config/locales/moldels/ko.yml
@@ -1,0 +1,30 @@
+ko:
+  activerecord:
+    attributes:
+      review:
+        conveniencestore: "편의점"
+        product_name: "상품명"
+        price: "가격"
+        rating: "평가"
+        category: "카테고리"
+        taste: "맛"
+        body: "리뷰 내용"
+        image: "이미지"
+  categories:
+    # korean_food: "한국 요리"
+    # japanese_food: "일본 요리"
+    # chinese_food: "중국 요리"
+    # western_food: "양식"
+    # snack: "스낵"
+    # drink: "음료"
+    dessert: "디저트"
+    # instant_food: "인스턴트 식품"
+  tastes:
+    spicy: "매운맛"
+    # sweet: "단맛"
+    # sour: "신맛"
+    # bitter: "쓴맛"
+    # salty: "짠맛"
+    # umami: "감칠맛"
+    # mild: "부드러운맛"
+    # rich: "진한맛"


### PR DESCRIPTION
### 実装内容

- フラッシュメッセージの修正
ログイン後とログアウト後のフラッシュメッセージの翻訳期待値が違った。
ログイン後、userのlanguageカラムの情報をsessionに保存する。
ログイン前のsessionを引きついでるのか、ログアウト後もsessionのものが
18n.localeとして残ったので修正

- データの中身を翻訳するための準備まで
全ての実装は次のbranchでおわらす